### PR TITLE
Update moneriote.sh

### DIFF
--- a/moneriote.sh
+++ b/moneriote.sh
@@ -24,8 +24,14 @@ echo $monerod
 echo $daemon
 
 ###
+if [ -d "$DIR" ] 
+then
+    echo "mkdir not needed because $DIR already exists" 
+else
+    echo "creating directory $DIR"
+    mkdir $DIR
+fi
 
-mkdir $DIR
 cp /home/main12/moneriote/*.html $DIR
 cd $DIR
 rm open_nodes.txt
@@ -64,7 +70,7 @@ do
 	echo "Checking ip: "$i
 	#Uncomment the below to check within the loop
 	#l_hit="$(curl -X POST http://$daemon:$bport/getheight -H 'Content-Type: application/json' | grep height | cut -f 2 -d : | cut -f 1 -d ,)"
-	r_hit="$(curl -m 0.5 -X POST http://$i:$port/getheight -H 'Content-Type: application/json' | grep height | cut -f 2 -d : | cut -f 1 -d ,)"
+	r_hit="$(curl -m 1 -X POST http://$i:$port/getheight -H 'Content-Type: application/json' | grep height | cut -f 2 -d : | cut -f 1 -d ,)"
 	echo "Local Height: "$l_hit
 	echo "Remote Height: "$r_hit
         mini=$(( $l_hit-10 ))


### PR DESCRIPTION
`curl -m` supports decimal numbers, but `0.5` is not recognized. 
Using `0.5` leads to the following error :
```
curl: option -m: expected a proper numerical parameter
```
Use `0,5` instead or just the whole number `1` like me. 
Tested on curl versions 7.52.1 and 7.58.0

Furthermore I have added a simple check to avoid  one error when $DIR already exists.